### PR TITLE
Add support for markdown view files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# Markdown rendering
+gem "redcarpet"
+gem "front_matter_parser"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.3.0)
       tzinfo
+    front_matter_parser (1.0.1)
     fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -254,6 +255,7 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
+    redcarpet (3.6.1)
     regexp_parser (2.11.2)
     reline (0.6.2)
       io-console (~> 0.5)
@@ -377,6 +379,7 @@ DEPENDENCIES
   brakeman
   capybara
   debug
+  front_matter_parser
   importmap-rails
   jbuilder
   kamal
@@ -384,6 +387,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2, >= 8.0.2.1)
+  redcarpet
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,4 +3,7 @@ class PagesController < ApplicationController
 
   def index
   end
+
+  def about
+  end
 end

--- a/app/views/pages/about.html.md
+++ b/app/views/pages/about.html.md
@@ -1,0 +1,41 @@
+---
+title: About Us
+layout: application
+description: Learn more about our company and mission
+---
+
+# About Our Company
+
+Welcome to our **training portal**! We are dedicated to providing high-quality educational content.
+
+## Our Mission
+
+We believe in making learning accessible to everyone. Our platform offers:
+
+- Interactive tutorials
+- Code examples
+- Best practices
+- Community support
+
+## Features
+
+### Markdown Support
+This page demonstrates our new markdown view support with the following features:
+
+- **ERB preprocessing**: Current time is <%= Time.current.strftime("%Y-%m-%d %H:%M:%S") %>
+- **Front matter parsing**: Page title from front matter: <%= @front_matter&.dig('title') || 'No title' %>
+- **Syntax highlighting** for code blocks:
+
+```ruby
+def hello_world
+  puts "Hello, World!"
+end
+```
+
+### Contact Information
+
+For more information, please reach out to us at [contact@example.com](mailto:contact@example.com).
+
+---
+
+*Last updated: <%= Date.current.strftime("%B %d, %Y") %>*

--- a/config/initializers/markdown.rb
+++ b/config/initializers/markdown.rb
@@ -1,0 +1,53 @@
+require "redcarpet"
+require "front_matter_parser"
+
+module MarkdownHandler
+  def self.erb
+    @erb ||= ActionView::Template.registered_template_handler(:erb)
+  end
+
+  def self.call(template, source)
+    if source.strip.start_with?("---")
+      parsed = FrontMatterParser::Parser.parse_file(template.identifier)
+      source = parsed.content
+      front_matter = parsed.front_matter
+
+      compiled_source = erb.call(template, source)
+
+      <<-RUBY
+        content_for :front_matter, #{front_matter.inspect} if defined?(content_for)
+        @front_matter = #{front_matter.inspect}
+        markdown = Redcarpet::Markdown.new(
+          Redcarpet::Render::HTML.new(
+            filter_html: false,
+            no_intra_emphasis: true,
+            tables: true,
+            fenced_code_blocks: true,
+            autolink: true,
+            strikethrough: true,
+            superscript: true
+          )
+        )
+        markdown.render((begin;#{compiled_source};end).to_s).html_safe
+      RUBY
+    else
+      compiled_source = erb.call(template, source)
+      <<-RUBY
+        markdown = Redcarpet::Markdown.new(
+          Redcarpet::Render::HTML.new(
+            filter_html: false,
+            no_intra_emphasis: true,
+            tables: true,
+            fenced_code_blocks: true,
+            autolink: true,
+            strikethrough: true,
+            superscript: true
+          )
+        )
+        markdown.render((begin;#{compiled_source};end).to_s).html_safe
+      RUBY
+    end
+  end
+end
+
+ActionView::Template.register_template_handler :md, MarkdownHandler

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "pages#index"
+
+  get "about" => "pages#about"
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -6,4 +6,17 @@ class PagesTest < ApplicationSystemTestCase
 
     assert_selector "h1", text: "Welcome to Training Portal"
   end
+
+  test "visiting the about page renders markdown" do
+    visit about_path
+
+    assert_selector "h1", text: "About Our Company"
+    assert_selector "h2", text: "Our Mission"
+    assert_selector "h3", text: "Markdown Support"
+    assert_selector "strong", text: "training portal"
+    assert_selector "code"
+    assert_text "def hello_world"
+    assert_text "Current time is"
+    assert_text "Page title from front matter: About Us"
+  end
 end


### PR DESCRIPTION
This PR implements support for `.html.md` files as Rails view templates, enabling content creators to write documentation using markdown syntax with ERB preprocessing and YAML front matter parsing.

## Acceptance Criteria
- [x] Markdown files (`.html.md`) can be rendered as Rails views
- [x] ERB syntax works within markdown files
- [x] YAML front matter is parsed and accessible in templates
- [x] Existing HTML layouts can wrap markdown content
- [x] System test validates markdown file rendering

Fixes #6